### PR TITLE
VIK788 - Adding deprecated note in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+
+#DEPRACATED json_api_client
+Go to [https://github.com/Yesware/yeti_json_api_client](https://github.com/Yesware/yeti_json_api_client)
+
 # JsonApiClient [![Build Status](https://travis-ci.org/chingor13/json_api_client.png)](https://travis-ci.org/chingor13/json_api_client) [![Code Climate](https://codeclimate.com/github/chingor13/json_api_client.png)](https://codeclimate.com/github/chingor13/json_api_client) [![Code Coverage](https://codeclimate.com/github/chingor13/json_api_client/coverage.png)](https://codeclimate.com/github/chingor13/json_api_client)
 
 This gem is meant to help you build an API client for interacting with REST APIs as laid out by [http://jsonapi.org](http://jsonapi.org). It attempts to give you a query building framework that is easy to understand (it is similar to ActiveRecord scopes).


### PR DESCRIPTION
Adding a deprecated note as we will be using yeti_json_api_client from now on.
